### PR TITLE
URL & Version to support QUELPA

### DIFF
--- a/lsp-pwsh.el
+++ b/lsp-pwsh.el
@@ -99,8 +99,7 @@ Must not nil.")
 (advice-add 'lsp-ui-sideline--extract-info :filter-return #'lsp-pwsh--filter-cr)
 
 ;;; Utils
-(defconst lsp-pwsh-unzip-script "powershell -noprofile -noninteractive \
--nologo -ex bypass Expand-Archive -path '%s' -dest '%s'"
+(defconst lsp-pwsh-unzip-script "%s -noprofile -noninteractive -nologo -ex bypass -command Expand-Archive -path '%s' -dest '%s'"
   "Powershell script to unzip vscode extension package file.")
 
 (defcustom lsp-pwsh-github-asset-url
@@ -123,7 +122,7 @@ FORCED if specified."
   (let ((parent-dir (file-name-directory lsp-pwsh-dir)))
     (unless (and (not forced) (file-exists-p parent-dir))
       (lsp-pwsh--get-extension
-       (format lsp-pwsh-github-asset-url "PowerShell" "PowerShellEditorServices" "PowerShellEditorServices.zip")
+       (format lsp-pwsh-github-asset-url (eval 'lsp-pwsh-exe) "PowerShell" "PowerShellEditorServices" "PowerShellEditorServices.zip")
        parent-dir)
       (message "lsp-pwsh: Downloading done!")))
   )

--- a/lsp-pwsh.el
+++ b/lsp-pwsh.el
@@ -4,7 +4,7 @@
 
 ;; Author: kien.n.quang@gmail.com
 ;; URL: https://github.com/kiennq/lsp-powershell
-;; Version: 0.0.1
+;; Package-Version: 0.0.1
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1") (lsp-mode "6.0") (dash) (s))
 

--- a/lsp-pwsh.el
+++ b/lsp-pwsh.el
@@ -3,6 +3,8 @@
 ;; Copyright (C) 2019  Kien Nguyen
 
 ;; Author: kien.n.quang@gmail.com
+;; URL: https://github.com/kiennq/lsp-powershell
+;; Version: 0.1
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1") (lsp-mode "6.0") (dash) (s))
 

--- a/lsp-pwsh.el
+++ b/lsp-pwsh.el
@@ -4,7 +4,7 @@
 
 ;; Author: kien.n.quang@gmail.com
 ;; URL: https://github.com/kiennq/lsp-powershell
-;; Version: 0.1
+;; Version: 0.0.1
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1") (lsp-mode "6.0") (dash) (s))
 

--- a/lsp-pwsh.el
+++ b/lsp-pwsh.el
@@ -4,7 +4,7 @@
 
 ;; Author: kien.n.quang@gmail.com
 ;; URL: https://github.com/kiennq/lsp-powershell
-;; Version: 0.1
+;; Package-Version: 20190411.1904
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1") (lsp-mode "6.0") (dash) (s))
 


### PR DESCRIPTION
Any chance you could accept this PR so that QUELPA stops complaining? I don't use `straight.el` (as I'm using `doom-emacs`) - the lack of a version is currently causing any installation to fail.