### PR TITLE
Make `lsp-pwsh-setup` command platform-agnostic

### DIFF
--- a/lsp-pwsh.el
+++ b/lsp-pwsh.el
@@ -99,8 +99,7 @@ Must not nil.")
 (advice-add 'lsp-ui-sideline--extract-info :filter-return #'lsp-pwsh--filter-cr)
 
 ;;; Utils
-(defconst lsp-pwsh-unzip-script "powershell -noprofile -noninteractive \
--nologo -ex bypass Expand-Archive -path '%s' -dest '%s'"
+(defconst lsp-pwsh-unzip-script "%s -noprofile -noninteractive -nologo -ex bypass -command Expand-Archive -path '%s' -dest '%s'"
   "Powershell script to unzip vscode extension package file.")
 
 (defcustom lsp-pwsh-github-asset-url
@@ -123,7 +122,7 @@ FORCED if specified."
   (let ((parent-dir (file-name-directory lsp-pwsh-dir)))
     (unless (and (not forced) (file-exists-p parent-dir))
       (lsp-pwsh--get-extension
-       (format lsp-pwsh-github-asset-url "PowerShell" "PowerShellEditorServices" "PowerShellEditorServices.zip")
+       (format lsp-pwsh-github-asset-url (eval 'lsp-pwsh-exe) "PowerShell" "PowerShellEditorServices" "PowerShellEditorServices.zip")
        parent-dir)
       (message "lsp-pwsh: Downloading done!")))
   )

--- a/lsp-pwsh.el
+++ b/lsp-pwsh.el
@@ -29,7 +29,7 @@
 (require 's)
 (require 'f)
 
-(defvar lsp-pwsh-exe (or (executable-find "pwsh") (executable-find "powershell"))
+(defvar lsp-pwsh-exe (or (executable-find "powershell") (executable-find "pwsh"))
   "PowerShell executable.")
 
 (defvar lsp-pwsh-dir (expand-file-name ".extension/pwsh/PowerShellEditorServices" user-emacs-directory)


### PR DESCRIPTION
Get the executable from `lsp-pwsh-exe` and add `-command` to the command definition so that this can be used cross-platform (i.e. on Unix PowerShell Core as well as Windows PowerShell)