### PR TITLE
Add Package-Version (+ URL) to fix QUELPA install

### DIFF
--- a/lsp-pwsh.el
+++ b/lsp-pwsh.el
@@ -3,6 +3,8 @@
 ;; Copyright (C) 2019  Kien Nguyen
 
 ;; Author: kien.n.quang@gmail.com
+;; URL: https://github.com/kiennq/lsp-powershell
+;; Package-Version: 20190411.1904
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1") (lsp-mode "6.0") (dash) (s))
 


### PR DESCRIPTION
I don't use `straight.el` and `QUELPA` requires that the `Package-Version` of a release is contained in the header. Also added the `URL` to the repository for completeness.